### PR TITLE
#9 Tags with `no more than one` prefix excluded from negative collection

### DIFF
--- a/specfix.js
+++ b/specfix.js
@@ -17,7 +17,7 @@ const writeFile = util.promisify(fs.writeFile);
             if (resultNegative.length > 1) {
                 let prevPart = '';
                 for (const part of resultNegative) {
-                    if (['no', 'not'].includes(prevPart.toLowerCase())) {
+                    if (['no', 'not'].includes(prevPart.toLowerCase()) && !part.trim().startsWith('more than one')) {
                         const filteredKeywords = keywords.filter(value => new RegExp(`\\b(${value})\\b`, 'gi').test(part));
                         negativeKeywords.push(...filteredKeywords);
                     }


### PR DESCRIPTION
* Now inside the specfix script, all tags with `no more than one` will not be included in the collection of negative tags for exclusion